### PR TITLE
Remove CLA, add note about bots

### DIFF
--- a/audit-template.md
+++ b/audit-template.md
@@ -52,8 +52,7 @@ _For notes on anything crossed out, look below. Note: I use `[ ]` to mean that I
 _Note: Neither of these are necessary, but they can help with some things. Check out https://probot.github.io/ for some tools._
 
 - [ ] Are there bots enabled?
-- [ ] Is there a CLA?
-  - [ ] Is there a bot to help with the CLA?
+- [ ] Are the bots listed in the Contribute or Readme files so that users can expect to interact with them?
 
 ### Metadata
 - [ ] Is there a description on GitHub?


### PR DESCRIPTION
The CLA wording was unnecessary. However, I think it is important to let users know that they may run into bots which enforce similar aspects of interacting with the repository; for instance, stale bot, CLA bots, and so on. Adding a note in the Contributing about various bots that work on the platform would be a good way of doing this that I have not seen widely adopted (read: at all) yet. But I think it would help here.

Closes #1.